### PR TITLE
Prevent occasional stuttering on the scrolling of the middle layer.

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -1556,17 +1556,17 @@ void cGraphics_Amiga::Mission_Intro_Play(const bool pShowHelicopter, const eTile
 		Video_Draw_16_Offset(word_4286F);
 
 		// Front
-		word_4286F += 4;
+		word_4286F += 5;
 		if (word_4286F >= 320)
 			word_4286F = 0;
 
 		// Middle
-		word_42871 += 2;
+		word_42871 += 4;
 		if (word_42871 >= 320)
 			word_42871 = 0;
 
 		// Back
-		word_42873 += 1;
+		word_42873 += 2;
 		if (word_42873 >= 320)
 			word_42873 = 0;
 

--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -1561,12 +1561,12 @@ void cGraphics_Amiga::Mission_Intro_Play(const bool pShowHelicopter, const eTile
 			word_4286F = 0;
 
 		// Middle
-		word_42871 += 3;
+		word_42871 += 2;
 		if (word_42871 >= 320)
 			word_42871 = 0;
 
 		// Back
-		word_42873 += 2;
+		word_42873 += 1;
 		if (word_42873 >= 320)
 			word_42873 = 0;
 


### PR DESCRIPTION
All the layers where scrolling fine (totally smooth), except the middle one, which showed occasional stuttering/juddering due to the fact that it was using an uneven position increase value (namely 3) while there is an even number of possible positions.