### PR TITLE
Fix Makefile's gitver.hpp output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ fodder: 	main
 		$(LD) -o Run/OpenFodder
 
 main:
-		git log -n 1 --pretty="const char* gitversion=\"%%h\";" > ./Source/gitver.hpp
+		git log -n 1 --pretty="const char* gitversion=\"%h\";" > ./Source/gitver.hpp
 		$(CC) Source/*.cpp Source/PC/*.cpp Source/Amiga/*.cpp Source/Structures/*.cpp Source/Utils/*.cpp Source/Map/*.cpp
 		mkdir -p obj
 


### PR DESCRIPTION
Before this change, this file is populated with a literal `%h` (at least on my machine), while it looks to me like the intention is to add the commit hash.