### PR TITLE
Add Flatpak data directory path for checking

### DIFF
--- a/Source/ResourceMan.cpp
+++ b/Source/ResourceMan.cpp
@@ -66,7 +66,14 @@ void cResourceMan::addDefaultDirs() {
 	if (path.size())
 		addBaseDir(path + "/Documents/");
 #else
-	char* path1 = std::getenv("XDG_DATA_DIRS");
+	//Per-user data dir (Flatpak: ~/.var/app/<app-id>/data)
+	char* path1 = std::getenv("XDG_DATA_HOME");
+    if (path1 && *path1) {
+        addBaseDir(std::string(path1) + "/");
+    }
+
+	//XDG_DATA_DIRS
+	path1 = std::getenv("XDG_DATA_DIRS");
 	if (path1) {
 		std::stringstream ss;
 		ss << path1;
@@ -76,11 +83,13 @@ void cResourceMan::addDefaultDirs() {
 			addBaseDir(substr);
 		}
 	}
+	//HOME -> ~/.local/share
 	path1 = std::getenv("HOME");
 	if (path1) {
 		path = path1;
 		addBaseDir(path + "/.local/share/");
 	}
+	//Fallback to /usr/local/share
 	addBaseDir("/usr/local/share/");
 #endif
 }


### PR DESCRIPTION
This PR will add the $XDG_DATA_HOME environment variable to the list of paths to check for data on startup.

As discussed in #97 and on Discord.

This allows a user who installs the Flatpak to extract the data zip and their game data files into `/home/<user>/.var/app/org.openFodder.OpenFodder/data/OpenFodder/` and for it to be picked up and loaded.
