### PR TITLE
Clamp Amiga DrawPixel plane count to prevent stack buffer overflow

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -1348,7 +1348,12 @@ void cGraphics_Amiga::Recruit_Sprite_Draw(int16 pRows, int16 pColumns, int16 pD2
 }
 
 void cGraphics_Amiga::DrawPixel(uint8* pSource, uint8* pDestination, uint16 pSourceX, uint16 pSourceY, uint16 pX, uint16 pY) {
-	uint8	Planes[5] = { 0, 0, 0, 0, 0 };
+	constexpr uint8 MaxSupportedPlanes = 5;
+	uint8	Planes[MaxSupportedPlanes] = { 0, 0, 0, 0, 0 };
+	uint8	PlaneCount = mBMHD_Current->mPlanes;
+
+	if (PlaneCount > MaxSupportedPlanes)
+		PlaneCount = MaxSupportedPlanes;
 
 	pSource += (pSourceX / 8);
 	pSource += (pSourceY * 40);
@@ -1358,7 +1363,7 @@ void cGraphics_Amiga::DrawPixel(uint8* pSource, uint8* pDestination, uint16 pSou
 
 
 	// Load bits for all planes
-	for (uint8 Plane = 0; Plane < mBMHD_Current->mPlanes; ++Plane)
+	for (uint8 Plane = 0; Plane < PlaneCount; ++Plane)
 		Planes[Plane] = *(pSource + ((mBMHD_Current->mHeight * 40) * Plane));
 
 	// Loop each pixel 
@@ -1367,7 +1372,7 @@ void cGraphics_Amiga::DrawPixel(uint8* pSource, uint8* pDestination, uint16 pSou
 	uint8 Result = 0;
 
 	// Value for each plane
-	for (uint8 Plane = 0; Plane < mBMHD_Current->mPlanes; ++Plane) {
+	for (uint8 Plane = 0; Plane < PlaneCount; ++Plane) {
 		Result |= Planes[Plane] & Bit ? (1 << Plane) : 0;
 	}
 


### PR DESCRIPTION
### Motivation
- The Amiga `DrawPixel` routine used a fixed `uint8 Planes[5]` stack buffer while iterating up to `mBMHD_Current->mPlanes` parsed from untrusted ILBM BMHD data, allowing out-of-bounds stack writes for malformed assets. 
- The animated Amiga intro invokes this path automatically on first run, increasing exposure to attacker-controlled local data files.

### Description
- Introduces `constexpr uint8 MaxSupportedPlanes = 5` and a local `PlaneCount` variable that is clamped to that maximum. 
- Both the plane-load loop and the per-pixel compose loop now iterate to `PlaneCount` instead of `mBMHD_Current->mPlanes`. 
- The change is limited to `cGraphics_Amiga::DrawPixel` in `Source/Amiga/Graphics_Amiga.cpp` and preserves rendering behavior for valid 5-plane assets.

### Testing
- No project unit tests or CI were executed in this environment; the patch was applied and committed successfully. 
- Verified the change via `git diff`, `nl`, and file inspection of `Source/Amiga/Graphics_Amiga.cpp` to confirm the bounds check and loop updates were added. 
- The fix is minimal and removes the stack-buffer-overflow root cause by preventing indexing past the local `Planes` buffer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e5a5aee4832cbc05c4c772a09473)