### PR TITLE
Guard Amiga hill sprite copy against short buffers

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -292,6 +292,13 @@ void cGraphics_Amiga::Load_Hill_Data() {
 	mImageHillSprites = Decode_Image("hills", 64);
 	mImageHillSprites.mData->resize(mImageHillBackground.GetHeader()->ScreenSize() * (mImageHillBackground.GetHeader()->mPlanes + 30));
 
+	// Legacy code below writes to fixed offsets in the hill sprite buffer.
+	// Ensure the decoded image is large enough before using those offsets.
+	constexpr size_t kHillSpriteMinSize = 0x42A0E;
+	if (mImageHillSprites.mData->size() < kHillSpriteMinSize) {
+		return;
+	}
+
 	// A5A7E
 	uint8* a0 = mImageHillSprites.mData->data() + (29 * 40);
 	uint8* a1 = mImageHillSprites.mData->data() + 0x390EE + 0x3E8;


### PR DESCRIPTION
### Motivation
- The legacy Amiga hill-loading code performs writes at hard-coded offsets into `mImageHillSprites` after sizing that buffer from attacker-controlled `hills.lbm` BMHD fields, which can lead to out-of-bounds heap writes when a crafted asset uses small dimensions/plane counts. 
- A minimal runtime guard is needed to prevent the legacy fixed-offset copy loop from accessing memory beyond the decoded buffer.

### Description
- Add a minimum-size check in `cGraphics_Amiga::Load_Hill_Data()` to ensure `mImageHillSprites.mData` is at least `0x42A0E` bytes before running the legacy fixed-offset copy loop. 
- Return early from `Load_Hill_Data()` when the decoded hill sprite buffer is too small, preserving existing behavior for valid assets. 
- Change is localized to `Source/Amiga/Graphics_Amiga.cpp` and does not alter the copy logic itself, only guards its execution.

### Testing
- Ran an automated offset computation script to derive the highest accessed byte and confirm the required minimum buffer size (script succeeded and produced `0x42A0E` as the threshold). 
- Applied the patch and performed an automated source inspection to verify the inserted `constexpr size_t kHillSpriteMinSize = 0x42A0E;` check is present before the legacy copy loop (inspection succeeded). 
- The patch was applied successfully without modifying the legacy copy logic, and no automated unit tests were run against the runtime code path in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10eabb3fd8832c8e1ceca2b42a03e6)