### PR TITLE
Clamp Amiga palette copy size to destination capacity

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -391,8 +391,11 @@ void cGraphics_Amiga::Load_And_Draw_Image(const std::string& pFilename, unsigned
 		Decoded.mDimension.mHeight = 0x101;
 	}
 
-	// Load the palette
-	Decoded.CopyPalette(mPalette, (1LL << Decoded.mPlanes));
+	// Load the palette (clamped to avoid overflow/UB from file-controlled plane counts)
+	const size_t PaletteCapacity = sizeof(mPalette) / sizeof(mPalette[0]);
+	const size_t PlaneCount = static_cast<size_t>(Decoded.mPlanes);
+	const size_t RequestedColors = (PlaneCount < (sizeof(size_t) * 8)) ? (1ULL << PlaneCount) : PaletteCapacity;
+	Decoded.CopyPalette(mPalette, std::min(RequestedColors, PaletteCapacity));
 
 	mBMHD_Current = Decoded.GetHeader();
 


### PR DESCRIPTION
### Motivation
- Prevent memory corruption when parsing Amiga IFF/BMHD images where the file-controlled `mPlanes` value can cause an oversized palette copy into the fixed-size Amiga palette.

### Description
- In `Source/Amiga/Graphics_Amiga.cpp` replace the unchecked `Decoded.CopyPalette(mPalette, (1 << Decoded.mPlanes))` with a safe calculation that computes `PaletteCapacity = sizeof(mPalette)/sizeof(mPalette[0])`, guards the left shift width, derives `RequestedColors` from `Decoded.mPlanes`, and calls `Decoded.CopyPalette(mPalette, std::min(RequestedColors, PaletteCapacity))` to clamp the copy size to the destination capacity.

### Testing
- Ran `git diff --check` to validate the patch formatting and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10eadd5d84832c8887da1bd9e20357)