### PR TITLE
Fix CMAP palette bounds in Amiga ILBM decoder

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -615,9 +615,11 @@ sImage cGraphics_Amiga::DecodeIFF(const std::string& pFilename) {
 				d0 = (int16)d0;
 				Final += d0;
 
-				Result.mPalette[i].mRed = ((Final >> 8) & 0xF) << 2;
-				Result.mPalette[i].mGreen = ((Final >> 4) & 0xF) << 2;
-				Result.mPalette[i].mBlue = ((Final >> 0) & 0xF) << 2;
+				if (i < 256) {
+					Result.mPalette[i].mRed = ((Final >> 8) & 0xF) << 2;
+					Result.mPalette[i].mGreen = ((Final >> 4) & 0xF) << 2;
+					Result.mPalette[i].mBlue = ((Final >> 0) & 0xF) << 2;
+				}
 
 				FileSize -= 3;
 


### PR DESCRIPTION
### Motivation
- Prevent an out-of-bounds write when decoding ILBM `CMAP` chunks into the fixed 256-entry `sImage::mPalette` which could be triggered by crafted/oversized CMAP chunks in attacker-controlled assets.

### Description
- Add a bounds check (`if (i < 256)`) around writes to `Result.mPalette[i]` in `Source/Amiga/Graphics_Amiga.cpp::DecodeIFF` while continuing to consume CMAP bytes so parsing behavior for valid assets is preserved.

### Testing
- Ran `git diff -- Source/Amiga/Graphics_Amiga.cpp && git status --short` to verify the change and it reported the expected diff; the command succeeded.
- Committed the change with `git add Source/Amiga/Graphics_Amiga.cpp && git commit -m "Fix CMAP palette bounds in Amiga ILBM decoder"` and the commit succeeded.
- Inspected the patched lines with `nl -ba Source/Amiga/Graphics_Amiga.cpp | sed -n '600,635p'` to confirm the bounds check is present and that command succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10eb7cc49c832ca33bf2b99177fab0)