### PR TITLE
Guard PC resource buffer accesses against truncated DAT files

### DIFF
--- a/Source/Graphics.hpp
+++ b/Source/Graphics.hpp
@@ -77,6 +77,10 @@ public:
 	void LoadPalette(size_t pFrom, const size_t pCount, const size_t pStartColorID = 0) {
 
 		auto Buffer = mData->data();
+		const size_t BufferSize = mData->size();
+		const size_t PaletteBytes = pCount * 3;
+		if (pFrom >= BufferSize || (BufferSize - pFrom) < PaletteBytes)
+			return;
 
 		for (size_t ColorID = pStartColorID; ColorID < pStartColorID + pCount; ColorID++) {
 

--- a/Source/PC/Graphics_PC.cpp
+++ b/Source/PC/Graphics_PC.cpp
@@ -203,7 +203,8 @@ void cGraphics_PC::Load_Hill_Data() {
 
 	// Parts of this surface have the recruits from mImageRecruit copied onto it
 	mImageHillSprites = Decode_Image("hill.dat", 0x50, 0xFA00, 0x00);
-	for (uint32 x = 0; x < 0xA000; ++x) {
+	const uint32 ClearCount = std::min<uint32>(0xA000, mImageHillSprites.mData->size());
+	for (uint32 x = 0; x < ClearCount; ++x) {
 		mImageHillSprites.mData->data()[x] = 0;
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix out-of-bounds reads and writes triggered when resource DAT files are undersized because file-backed `std::vector<uint8>` buffers replace legacy fixed-size buffers while code still reads/writes fixed offsets.

### Description
- Add a bounds check to `sImage::LoadPalette` so it returns early if `pFrom` + (`pCount` * 3) would exceed the backing buffer size, preventing palette reads past the end of the file buffer.
- Cap the recruit hill-sprite clear loop to `min(0xA000, mImageHillSprites.mData->size())` so writes do not overflow when `hill.dat` is truncated.
- Changes are minimal and localized to the vulnerable PC graphics paths in `Source/Graphics.hpp` and `Source/PC/Graphics_PC.cpp` and preserve behavior for correctly-sized original assets.

### Testing
- Ran repository sanity and inspection commands (`git diff`, `nl -ba` excerpts) to verify the patch is applied and the modified lines appear as expected, and `git commit` succeeded for the change.
- Created the PR metadata with `make_pr` to record the change. 
- An earlier automated ASan build attempt (during vulnerability validation) revealed the issue but could not be re-run post-patch because the environment lacks SDL2 development headers (`sdl2-config` / `SDL.h`), so full ASan verification could not be completed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ee45e544832cbe1db5ef5ba66f9d)