### PR TITLE
Fix Amiga sprite left-clip negative X underwrite

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -215,6 +215,9 @@ bool cGraphics_Amiga::Sprite_OnScreen_Check(bool p16bit) {
 		}
 
 		mFodder->mVideo_Draw_FrameDataPtr += ax;
+
+		if (mFodder->mVideo_Draw_PosX < 0)
+			return false;
 	}
 
 	ax = mFodder->mVideo_Draw_PosX + drawColumns;


### PR DESCRIPTION
### Motivation
- Prevent negative sprite X positions from surviving left-edge clipping in the Amiga renderer and causing an out-of-bounds write in `Video_Draw_8` when `mVideo_Draw_PosX` can be -1.

### Description
- Add a post-left-clip safety check in `cGraphics_Amiga::Sprite_OnScreen_Check(bool)` that returns `false` if `mVideo_Draw_PosX < 0`, implemented as a minimal three-line change in `Source/Amiga/Graphics_Amiga.cpp` to reject sprites that would underwrite the surface buffer.

### Testing
- No full automated test suite was executed due to missing SDL development headers in the environment, and the change was verified via source-level checks (`git diff` and `nl -ba`) which confirmed the intended insertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e489f190832c8306c22d5659d2cb)