### PR TITLE
Fix Amiga2 palette bounds handling

### DIFF
--- a/Source/Amiga/Graphics_Amiga2.cpp
+++ b/Source/Amiga/Graphics_Amiga2.cpp
@@ -98,10 +98,11 @@ tSharedBuffer cGraphics_Amiga2::GetPalette(const std::string pFilename) {
     auto Palette = g_Resource->fileGet(Filename);
 
     auto a0 = Palette->data();
-    for (; a0 < Palette->data() + Palette->size(); ++a0) {
+    auto a0End = Palette->data() + Palette->size();
+    for (; a0 + 2 < a0End; a0 += 3) {
 
-        uint16 d0 = *a0++;
-        uint16 d1 = *a0++;
+        uint16 d0 = a0[0];
+        uint16 d1 = a0[1];
 
         d0 &= 0xF0;
         d0 <<= 4;
@@ -109,7 +110,7 @@ tSharedBuffer cGraphics_Amiga2::GetPalette(const std::string pFilename) {
         d1 &= 0xF0;
         d0 |= d1;
 
-        d1 = *a0;
+        d1 = a0[2];
         d1 &= 0xF0;
         d1 >>= 4;
         d0 |= d1;

--- a/Source/Graphics.hpp
+++ b/Source/Graphics.hpp
@@ -94,7 +94,13 @@ public:
 
 		uint16 color;
 
-		for (size_t ColorID = pStartColorID; ColorID < pStartColorID + pCount; ColorID++) {
+		if (pStartColorID >= 256)
+			return;
+
+		const size_t MaxColors = 256 - pStartColorID;
+		const size_t PaletteCount = std::min(pCount, MaxColors);
+
+		for (size_t ColorID = pStartColorID; ColorID < pStartColorID + PaletteCount; ColorID++) {
 
 			// Get the next color codes
 			color = readBEWord(pFrom);


### PR DESCRIPTION
### Motivation
- The Amiga2 palette parser and loader could read past the end of `.PAL` buffers and write past the fixed 256-entry `mPalette` array, enabling local asset-triggered memory corruption. 
- The new CF2 Amiga path exposed this by parsing `.PAL` as 3-byte triplets while callers passed byte counts to the loader and some calls start at high palette indices (e.g. `0xE0`).

### Description
- Hardened `cGraphics_Amiga2::GetPalette()` to only consume complete 3-byte RGB triplets by iterating with `for (; a0 + 2 < a0End; a0 += 3)` and using `a0[0]`, `a0[1]`, `a0[2]` for conversion to avoid out-of-bounds reads. (file: `Source/Amiga/Graphics_Amiga2.cpp`)
- Ensured palette conversion pushes the intended two output bytes per color while using a bounds-safe source loop. (file: `Source/Amiga/Graphics_Amiga2.cpp`)
- Clamped `sImage::LoadPalette_Amiga()` to the valid `mPalette` range by early-returning if `pStartColorID >= 256` and using `std::min(pCount, 256 - pStartColorID)` for the loop count to prevent out-of-bounds writes. (file: `Source/Graphics.hpp`)

### Testing
- Inspected changed files with `rg` and `sed` to verify modifications, and the checks succeeded. 
- Verified the resulting diff with `git diff -- Source/Amiga/Graphics_Amiga2.cpp Source/Graphics.hpp` and it showed the intended changes. 
- Committed the changes with `git add` / `git commit` and created the PR metadata via `make_pr`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d63e41b4832c9046044ae88e6ab1)