### PR TITLE
Harden Amiga CF2 sprite loading against palette and RAW OOB access

### DIFF
--- a/Source/Amiga/Graphics_Amiga2.cpp
+++ b/Source/Amiga/Graphics_Amiga2.cpp
@@ -38,6 +38,17 @@ void cGraphics_Amiga2::Map_Load_Resources() {
     mSpriteSheet_InGame2.mDimension.mHeight = 0x151;
     mSpriteSheet_InGame1.mDimension.mHeight = 0x150;
 
+    auto ValidateRawSize = [](sImage& pImage) {
+        const size_t RowStrideBytes = pImage.mDimension.mWidth >> 3;
+        const size_t RequiredBytes = RowStrideBytes * pImage.mDimension.mHeight * pImage.mPlanes;
+
+        if (pImage.mData->size() < RequiredBytes)
+            pImage = sImage();
+    };
+
+    ValidateRawSize(mSpriteSheet_InGame2);
+    ValidateRawSize(mSpriteSheet_InGame1);
+
     SetActiveSpriteSheet(eGFX_IN_GAME);
 }
 
@@ -141,6 +152,11 @@ sImage cGraphics_Amiga2::GetImage(const std::string& pFilename, const size_t pPa
 
     Decoded.mDimension.mWidth = 0x140;
     Decoded.mDimension.mHeight = 0x100;
+
+    const size_t RowStrideBytes = Decoded.mDimension.mWidth >> 3;
+    const size_t RequiredBytes = RowStrideBytes * Decoded.mDimension.mHeight * Decoded.mPlanes;
+    if (Decoded.mData->size() < RequiredBytes)
+        return sImage();
 
     Decoded.LoadPalette_Amiga((uint8*)Palette->data(), Palette->size() / 2, pPaletteIndex);
 

--- a/Source/Graphics.hpp
+++ b/Source/Graphics.hpp
@@ -93,8 +93,14 @@ public:
 	void LoadPalette_Amiga( const uint8 *pFrom, const size_t pCount, const size_t pStartColorID = 0 ) {
 
 		uint16 color;
+		const size_t PaletteLimit = sizeof(mPalette) / sizeof(mPalette[0]);
 
-		for (size_t ColorID = pStartColorID; ColorID < pStartColorID + pCount; ColorID++) {
+		if (pStartColorID >= PaletteLimit)
+			return;
+
+		const size_t ColorsToRead = std::min(pCount, PaletteLimit - pStartColorID);
+
+		for (size_t ColorID = pStartColorID; ColorID < pStartColorID + ColorsToRead; ColorID++) {
 
 			// Get the next color codes
 			color = readBEWord(pFrom);


### PR DESCRIPTION
### Motivation
- A CF2 Amiga map/sprite loader feeds user-supplied `.PAL` and `.RAW` assets into legacy helpers that assumed well-formed inputs, allowing oversized palette data to write past a fixed 256-entry palette and undersized RAWs to trigger out-of-bounds reads/crashes during sprite drawing.
- The change prevents local malicious or malformed data packs from causing memory corruption or crashes by validating lengths before use.

### Description
- Clamp `sImage::LoadPalette_Amiga()` writes to the fixed 256-entry palette by bounding the number of colors read and early-returning when `pStartColorID` is out of range, preventing out-of-bounds palette writes; changed in `Source/Graphics.hpp` (`LoadPalette_Amiga`).
- Validate `.RAW` buffer size in `cGraphics_Amiga2::GetImage()` and reject undersized decoded images before they are used, preventing downstream reads from truncated image buffers; changed in `Source/Amiga/Graphics_Amiga2.cpp` (`GetImage`).
- After the CF2-specific height overrides in `cGraphics_Amiga2::Map_Load_Resources()` add a size check for the loaded sprite sheets and drop invalid sheets to avoid later sprite-drawing OOB accesses; changed in `Source/Amiga/Graphics_Amiga2.cpp` (`Map_Load_Resources`).

### Testing
- Attempted a full CMake configure/build with `cmake -S . -B build && cmake --build build -j2`, but configuration fails in this environment due to a missing SDL3 development package (`SDL3Config.cmake`/`sdl3-config.cmake`), so an end-to-end build could not be completed.
- No automated unit tests were present or run in this environment; the fix is intentionally minimal and localized to the three functions to preserve existing behavior while preventing OOB reads/writes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d7b6c248832c8e28e8ef4579626e)