### PR TITLE
Fix PC sprite left-edge clipping underwrite

### DIFF
--- a/Source/PC/Graphics_PC.cpp
+++ b/Source/PC/Graphics_PC.cpp
@@ -694,6 +694,14 @@ bool cGraphics_PC::Sprite_OnScreen_Check() {
 		mFodder->mVideo_Draw_Columns -= ax;
 		ax >>= 1;
 		mFodder->mVideo_Draw_FrameDataPtr += ax;
+
+		// Ensure the destination X never remains negative after clipping.
+		// A remaining -1 here would underflow the destination pointer in Video_Draw_8.
+		if (mFodder->mVideo_Draw_PosX < 0)
+		{
+			++mFodder->mVideo_Draw_PosX;
+			--mFodder->mVideo_Draw_Columns;
+		}
 	}
 
 	ax = mFodder->mVideo_Draw_PosX + mFodder->mVideo_Draw_Columns;


### PR DESCRIPTION
### Motivation
- Prevent a heap-buffer underwrite in the PC renderer where left-edge clipping could leave `mVideo_Draw_PosX` negative and cause `Video_Draw_8` to write before the row/buffer start.

### Description
- Add a post-clip guard in `cGraphics_PC::Sprite_OnScreen_Check` (`Source/PC/Graphics_PC.cpp`) that advances `mVideo_Draw_PosX` to non-negative and reduces `mVideo_Draw_Columns` when left-edge clipping would otherwise leave `PosX < 0`.

### Testing
- No automated unit tests were run against the patched code in this environment; a full build with SDL headers was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d47e1b64832cb86dd68a36da3cdd)