### PR TITLE
Guard CF1 sprite loading against sprite array overflow

### DIFF
--- a/Source/Map/Original.cpp
+++ b/Source/Map/Original.cpp
@@ -99,6 +99,10 @@ void cOriginalMap::loadCF1Spt(tSharedBuffer pSpriteData, bool pCF2) {
 
 
 	for (uint16 HumanCount = 0; SptPtr != SptFileEnd; ++Sprite) {
+		if (Sprite >= mSprites.data() + mSprites.size()) {
+			break;
+		}
+
 		++SptPtr;
 		Sprite->mSheetIndex = 0x7C;
 
@@ -127,6 +131,10 @@ void cOriginalMap::loadCF1Spt(tSharedBuffer pSpriteData, bool pCF2) {
 		if (pCF2) {
 			if (Sprite > mSprites.data())
 				if (Sprite->mSpriteType == 4 && (Sprite - 1)->mSpriteType >= 114 && (Sprite - 1)->mSpriteType <= 117) {
+					if ((Sprite + 1) >= (mSprites.data() + mSprites.size())) {
+						break;
+					}
+
 					++Sprite;
 				}
 		}


### PR DESCRIPTION
### Motivation
- A CF2-specific hack in the CF1 sprite parser could advance the destination `Sprite` pointer an extra time without checking the fixed `mSprites` capacity, allowing crafted `.spt` data to write past the `mSprites` buffer and corrupt adjacent object memory. 
- The change aims to prevent out-of-bounds writes while preserving original parsing behavior and the CF2 compatibility heuristic.

### Description
- Added a destination-capacity guard at the top of the parse loop in `cOriginalMap::loadCF1Spt` to stop parsing when `Sprite` has reached `mSprites.size()` in `Source/Map/Original.cpp`. 
- Added an upper-bound check inside the CF2 compatibility branch to ensure the `++Sprite` skip cannot advance past the end of `mSprites`.
- The change preserves the existing parsing semantics by breaking out of the loop when no sprite slots remain instead of attempting further writes.

### Testing
- Ran repository searches (`rg`) to verify locations of `Map_Load_Sprites` / CF2 hack patterns and confirmed the modified code region was updated successfully, and the commands completed with no errors. 
- Inspected the updated file diff (`git diff`) and line numbering (`nl`) to confirm the bounds checks were inserted at the intended locations, and those checks verified as present. 
- No full build or unit-test suite was executed in this environment due to missing SDL build dependencies, so runtime tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d2f29130832c843965cfaaf72cd7)