### PR TITLE
Clamp sprite limit inputs to prevent OOB and exhaustion

### DIFF
--- a/Source/Parameters.cpp
+++ b/Source/Parameters.cpp
@@ -31,7 +31,7 @@ using Json = nlohmann::json;
 cxxopts::Options* sFodderParameters::mCliOptions = 0;
 
 /* These values override the original engine values, when in custom mode */
-const size_t CUSTOM_DEFAULT_MAX_SPRITES = 100000;
+const size_t CUSTOM_DEFAULT_MAX_SPRITES = sFodderParameters::MAX_SPRITES_MAX;
 const size_t CUSTOM_DEFAULT_MAX_SPAWN = 25;
 
 std::string sFodderParameters::ToJson() {
@@ -90,8 +90,10 @@ bool sFodderParameters::FromJson(const std::string& pJson) {
 		else
 			mSpritesMax = 45; // The original engine limit
 
-		if (mSpritesMax < 16)
-			mSpritesMax = 16;
+		if (mSpritesMax < MIN_SPRITES_MAX)
+			mSpritesMax = MIN_SPRITES_MAX;
+		if (mSpritesMax > MAX_SPRITES_MAX)
+			mSpritesMax = MAX_SPRITES_MAX;
 	}
 
 	// Max Spawned
@@ -309,8 +311,10 @@ bool sFodderParameters::ProcessCLI(int argc, char *argv[]) {
 		if (result.count("max-spawn"))
 			mSpawnEnemyMax = result["max-spawn"].as<uint32_t>();
 
-		if (mSpritesMax < 16)
-			mSpritesMax = 16;
+		if (mSpritesMax < MIN_SPRITES_MAX)
+			mSpritesMax = MIN_SPRITES_MAX;
+		if (mSpritesMax > MAX_SPRITES_MAX)
+			mSpritesMax = MAX_SPRITES_MAX;
 
 		// Cheats perm enabled in debug build
 #ifdef _DEBUG
@@ -507,6 +511,11 @@ bool sFodderParameters::ProcessINI() {
 			auto maxspawn = ini.get("maxspawn", 0);
 			if (maxspawn)
 				mSpawnEnemyMax = maxspawn;
+
+			if (mSpritesMax < MIN_SPRITES_MAX)
+				mSpritesMax = MIN_SPRITES_MAX;
+			if (mSpritesMax > MAX_SPRITES_MAX)
+				mSpritesMax = MAX_SPRITES_MAX;
 		}
 	}
 

--- a/Source/Parameters.hpp
+++ b/Source/Parameters.hpp
@@ -80,6 +80,9 @@ public:
 	size_t mSpritesMax;
 	size_t mSpawnEnemyMax;
 
+	static constexpr size_t MIN_SPRITES_MAX = 45;
+	static constexpr size_t MAX_SPRITES_MAX = 100000;
+
 	bool mShowHelp;
 	bool mCopyProtection;
 


### PR DESCRIPTION
### Motivation
- The code made `mSpritesMax` externally controllable (CLI/INI/demo JSON) while many engine paths still assume at least 45 sprites, allowing out-of-bounds writes and memory-exhaustion via crafted inputs.\
- Introduce a minimal, centralized validation to prevent malicious or accidental underflow/overflow of the sprite vector while preserving original defaults.

### Description
- Added `MIN_SPRITES_MAX = 45` and `MAX_SPRITES_MAX = 100000` constants to `sFodderParameters` in `Source/Parameters.hpp` to centralize safe bounds.\
- Tied `CUSTOM_DEFAULT_MAX_SPRITES` to the new `MAX_SPRITES_MAX` to keep custom-mode defaults consistent in `Source/Parameters.cpp`.\
- Clamped `mSpritesMax` to the `[MIN_SPRITES_MAX, MAX_SPRITES_MAX]` range when loading from demo/save JSON in `sFodderParameters::FromJson`.\
- Clamped `mSpritesMax` after parsing CLI (`--max-sprite`) in `sFodderParameters::ProcessCLI` and after reading `engine.maxsprite` from `openfodder.ini` in `sFodderParameters::ProcessINI` to cover all untrusted input paths.\

### Testing
- No unit tests were executed for this change.\
- Performed automated code searches with `rg` to verify all input code paths (`mSpritesMax`, `--max-sprite`, `Sprite_Clear_All`, `Map_Load_Sprites`) are covered by the clamping changes and inspected diffs with `git diff`, which succeeded.\
- Changes were committed successfully with the message `Clamp max sprite parameter to safe range`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d06cbd2c832ca6b9b49d93bbe180)