### PR TITLE
Harden loose-resource RNC decompression checks

### DIFF
--- a/Source/Resources.cpp
+++ b/Source/Resources.cpp
@@ -38,15 +38,29 @@ tSharedBuffer cResources::fileGet( std::string pFilename ) {
 }
 
 tSharedBuffer cResources::fileDeRNC(tSharedBuffer pBuffer) {
+	constexpr uint32 RNCHeaderSize = 18;
+	constexpr uint32 MaxUnpackedSize = 64 * 1024 * 1024;
+
+	if (pBuffer->size() < RNCHeaderSize)
+		return pBuffer;
+
 	uint32 Header = readBEDWord(pBuffer->data());
 	if (Header != 'RNC\01')
 		return pBuffer;
 
 	uint32 Size = readBEDWord(pBuffer->data() + 4);
+	uint32 PackedSize = readBEDWord(pBuffer->data() + 8);
+
+	if ((PackedSize > (pBuffer->size() - RNCHeaderSize)) || !Size || (Size > MaxUnpackedSize))
+		return pBuffer;
 
 	auto Unpacked = std::make_shared<std::vector<uint8>>();
 	Unpacked->resize(Size);
-	rnc_unpack(pBuffer->data(), Unpacked->data());
+
+	long Result = rnc_unpack(pBuffer->data(), Unpacked->data());
+	if (Result != static_cast<long>(Size))
+		return pBuffer;
+
 	return Unpacked;
 }
 


### PR DESCRIPTION
### Motivation
- Close an unsafe decompression path introduced in the base resource loader where any non-empty loose resource could be treated as RNC and fed to the unpacker without size or result validation. 
- Prevent out-of-bounds reads, uncontrolled allocations, crashes, or potential memory corruption when parsing malformed or attacker-controlled loose assets (including DOS Amiga-audio replacements).

### Description
- In `Source/Resources.cpp` added a minimum-header length guard (`RNCHeaderSize = 18`) to avoid reading header fields from short buffers. 
- Read and validate the packed-size field and ensure `PackedSize <= (buffer_size - RNCHeaderSize)`, and reject zero or excessively large unpacked sizes with a 64 MiB cap (`MaxUnpackedSize`).
- Allocate the unpack buffer only after validation and call `rnc_unpack`, then verify the unpacker return value matches the expected unpacked size and fall back to returning the original buffer on any failure. 
- The changes are localized to `cResources::fileDeRNC` to provide a minimal defense-in-depth fix while preserving existing resource-loading behavior for valid data.

### Testing
- No automated tests were executed for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10cf13dfa4832c858532bab47ca277)