### PR TITLE
Fix DecodeIFF CMAP palette bounds check

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -618,7 +618,7 @@ sImage cGraphics_Amiga::DecodeIFF(const std::string& pFilename) {
 				d0 = (int16)d0;
 				Final += d0;
 
-				if (i < 256) {
+				if (i < std::size(Result.mPalette)) {
 					Result.mPalette[i].mRed = ((Final >> 8) & 0xF) << 2;
 					Result.mPalette[i].mGreen = ((Final >> 4) & 0xF) << 2;
 					Result.mPalette[i].mBlue = ((Final >> 0) & 0xF) << 2;


### PR DESCRIPTION
### Motivation
- Prevent an invalid `.size()` call and avoid a magic-number bound when writing CMAP entries in `cGraphics_Amiga::DecodeIFF`, ensuring the palette write guard matches the actual `mPalette` storage.

### Description
- Replace the hard-coded check `if (i < 256)` with `if (i < std::size(Result.mPalette))` in `cGraphics_Amiga::DecodeIFF` to correctly guard CMAP palette writes.

### Testing
- Ran `git diff --check` to validate the patch formatting and found no issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1261d86870832ca0b6be6f74069e5d)