### PR TITLE
Fix RNC fail-open path and palette bounds compile error

### DIFF
--- a/Source/Amiga/Graphics_Amiga.cpp
+++ b/Source/Amiga/Graphics_Amiga.cpp
@@ -628,7 +628,8 @@ sImage cGraphics_Amiga::DecodeIFF(const std::string& pFilename) {
 				d0 = (int16)d0;
 				Final += d0;
 
-				if (i < std::size(Result.mPalette)) {
+				const size_t PaletteCapacity = sizeof(Result.mPalette) / sizeof(Result.mPalette[0]);
+				if (i < PaletteCapacity) {
 					Result.mPalette[i].mRed = ((Final >> 8) & 0xF) << 2;
 					Result.mPalette[i].mGreen = ((Final >> 4) & 0xF) << 2;
 					Result.mPalette[i].mBlue = ((Final >> 0) & 0xF) << 2;

--- a/Source/Resources.cpp
+++ b/Source/Resources.cpp
@@ -40,6 +40,7 @@ tSharedBuffer cResources::fileGet( std::string pFilename ) {
 tSharedBuffer cResources::fileDeRNC(tSharedBuffer pBuffer) {
 	constexpr uint32 RNCHeaderSize = 18;
 	constexpr uint32 MaxUnpackedSize = 64 * 1024 * 1024;
+	const auto InvalidRNC = []() { return std::make_shared<std::vector<uint8>>(); };
 
 	if (pBuffer->size() < RNCHeaderSize)
 		return pBuffer;
@@ -52,14 +53,14 @@ tSharedBuffer cResources::fileDeRNC(tSharedBuffer pBuffer) {
 	uint32 PackedSize = readBEDWord(pBuffer->data() + 8);
 
 	if ((PackedSize > (pBuffer->size() - RNCHeaderSize)) || !Size || (Size > MaxUnpackedSize))
-		return pBuffer;
+		return InvalidRNC();
 
 	auto Unpacked = std::make_shared<std::vector<uint8>>();
 	Unpacked->resize(Size);
 
 	long Result = rnc_unpack(pBuffer->data(), Unpacked->data());
 	if (Result != static_cast<long>(Size))
-		return pBuffer;
+		return InvalidRNC();
 
 	return Unpacked;
 }


### PR DESCRIPTION
### Motivation
- A recent change caused recognized-but-invalid RNC resources to be returned as the original compressed buffer on validation or decompression failure, enabling downstream unbounded `memcpy` into fixed-size arrays and leading to memory corruption.
- The code also failed to build on some toolchains due to use of `std::size` on a raw array in `Graphics_Amiga.cpp`.

### Description
- In `Source/Resources.cpp` added an `InvalidRNC` helper that returns an empty shared byte buffer and changed the header/size validation and `rnc_unpack` mismatch branches to return `InvalidRNC()` instead of `pBuffer`, so malformed or failed-to-decompress RNC resources produce an empty buffer rather than attacker-controlled compressed bytes.
- In `Source/Amiga/Graphics_Amiga.cpp` replaced `std::size(Result.mPalette)` with a portable capacity calculation `sizeof(Result.mPalette) / sizeof(Result.mPalette[0])` before writing palette entries to fix the compile error.
- No other functional changes were introduced to resource loading callsites in this patch.

### Testing
- Attempted to build the target with `cmake --build . --target openfodder -j4`, but the build could not be executed in this environment due to a missing CMake cache (`Error: could not load cache`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269f49f4c832ca0ed7c40267c0155)